### PR TITLE
Fix compatibility with symfony messenger and framework bundle 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "sylius/sylius": "^1.3.1",
-        "symfony/messenger": "^4.2",
+        "symfony/messenger": "~4.3.0",
         "symfony/config": "^4.1",
         "symfony/dependency-injection": "^4.1",
         "symfony/http-kernel": "^4.1",

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,22 +7,24 @@
             <argument type="service" id="jms_serializer"/>
         </service>
 
+        <service id="sulu_sylius_producer.messenger_bus" alias="messenger.default_bus"/>
+
         <service id="Sulu\SyliusProducerPlugin\Producer\ProductMessageProducerInterface"
                  class="Sulu\SyliusProducerPlugin\Producer\ProductMessageProducer">
             <argument type="service" id="Sulu\SyliusProducerPlugin\Producer\Serializer\ProductSerializerInterface"/>
-            <argument type="service" id="messenger.bus.default"/>
+            <argument type="service" id="sulu_sylius_producer.messenger_bus"/>
         </service>
 
         <service id="Sulu\SyliusProducerPlugin\Producer\ProductVariantMessageProducerInterface"
                  class="Sulu\SyliusProducerPlugin\Producer\ProductVariantMessageProducer">
             <argument type="service" id="jms_serializer"/>
-            <argument type="service" id="messenger.bus.default"/>
+            <argument type="service" id="sulu_sylius_producer.messenger_bus"/>
         </service>
 
         <service id="Sulu\SyliusProducerPlugin\Producer\TaxonMessageProducerInterface"
                  class="Sulu\SyliusProducerPlugin\Producer\TaxonMessageProducer">
             <argument type="service" id="jms_serializer"/>
-            <argument type="service" id="messenger.bus.default"/>
+            <argument type="service" id="sulu_sylius_producer.messenger_bus"/>
         </service>
 
         <service id="Sulu\SyliusProducerPlugin\EventSubscriber\ProductEventSubscriber">


### PR DESCRIPTION
The `messenger.bus.default` does not exist and is called now `messenger.default_bus` that it can be easily be overwritten which bus is used I created a `sulu_sylius_producer.messenger_bus` which by default alias to the default bus.

E.g.:

```
# config/services.yaml

services:
    sulu_sylius_producer.messenger_bus:
        alias: messenger.bus.default
```