### PR TITLE
Prepend messenger configuration and allow messenger 4.2 and 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.1",
         "sylius/sylius": "^1.3.1",
-        "symfony/messenger": "~4.3.0",
+        "symfony/messenger": "~4.2.0 || ~4.3.0",
         "symfony/config": "^4.1",
         "symfony/dependency-injection": "^4.1",
         "symfony/http-kernel": "^4.1",

--- a/src/DependencyInjection/SuluSyliusProducerExtension.php
+++ b/src/DependencyInjection/SuluSyliusProducerExtension.php
@@ -16,10 +16,26 @@ namespace Sulu\SyliusProducerPlugin\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-final class SuluSyliusProducerExtension extends Extension
+final class SuluSyliusProducerExtension extends Extension implements PrependExtensionInterface
 {
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('framework')) {
+            $container->prependExtensionConfig('framework', [
+                'messenger' => [
+                    'buses' => [
+                        'sulu_sylius_producer.messenger_bus' => [
+                            'default_middleware' => 'allow_no_handlers',
+                        ]
+                    ]
+                ]
+            ]);
+        }
+    }
+
     public function load(array $config, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,8 +7,6 @@
             <argument type="service" id="jms_serializer"/>
         </service>
 
-        <service id="sulu_sylius_producer.messenger_bus" alias="messenger.default_bus"/>
-
         <service id="Sulu\SyliusProducerPlugin\Producer\ProductMessageProducerInterface"
                  class="Sulu\SyliusProducerPlugin\Producer\ProductMessageProducer">
             <argument type="service" id="Sulu\SyliusProducerPlugin\Producer\Serializer\ProductSerializerInterface"/>


### PR DESCRIPTION
We need to prepend the configuration for the messenger in the framework bundle.