### PR TITLE
Support newer Sylius and Symfony versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,10 +76,6 @@ jobs:
                 run: google-chrome-stable --enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --allow-insecure-localhost --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --window-size=2880,1800 --proxy-server='direct://' --proxy-bypass-list='*' http://127.0.0.1 > /dev/null 2>&1 &
 
             -
-                name: Run webserver
-                run: (cd tests/Application && symfony server:start --port=8080 --dir=public --daemon)
-
-            -
                 name: Get Composer cache directory
                 id: composer-cache
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -116,36 +112,8 @@ jobs:
                         ${{ runner.os }}-node-${{ matrix.node }}-yarn-
 
             -
-                name: Install JS dependencies
-                run: (cd tests/Application && yarn install)
-
-            -
-                name: Prepare test application database
-                run: |
-                    (cd tests/Application && bin/console doctrine:database:create -vvv)
-                    (cd tests/Application && bin/console doctrine:schema:create -vvv)
-
-            -
-                name: Prepare test application assets
-                run: |
-                    (cd tests/Application && bin/console assets:install public -vvv)
-                    (cd tests/Application && yarn build)
-
-            -
-                name: Prepare test application cache
-                run: (cd tests/Application && bin/console cache:warmup -vvv)
-
-            -
-                name: Load fixtures in test application
-                run: (cd tests/Application && bin/console sylius:fixtures:load -n)
-
-            -
                 name: Validate composer.json
                 run: composer validate --ansi --strict
-
-            -
-                name: Validate database schema
-                run: (cd tests/Application && bin/console doctrine:schema:validate)
 
             -
                 name: Run php-cs-fixer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,19 +19,15 @@ jobs:
     tests:
         runs-on: ubuntu-18.04
 
-        name: "PHP ${{ matrix.php }}, MySQL ${{ matrix.mysql }}"
+        name: "PHP ${{ matrix.php }}, MySQL ${{ matrix.mysql }}, Sylius ${{ matrix.sylius }}"
 
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 7.3]
+                php: [8.0, 8.1]
                 node: [10.x]
                 mysql: [5.7, 8.0]
-
-                exclude:
-                    - # PHP 7.3 does not support "caching_sha2_password" authentication plugin which is a default one in MySQL 8.0
-                        php: 7.3
-                        mysql: 8.0
+                sylius: [1.11.*, 1.12.*]
 
         env:
             APP_ENV: test
@@ -98,6 +94,10 @@ jobs:
                         ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
             -
+                name: Require Sylius version
+                run: composer require sylius/sylius:"${{ matrix.sylius }}" --no-update
+
+            -
                 name: Install PHP dependencies
                 run: composer install --no-interaction
 
@@ -148,7 +148,7 @@ jobs:
                 run: (cd tests/Application && bin/console doctrine:schema:validate)
 
             -
-                name: Run php-cs-fixer 
+                name: Run php-cs-fixer
                 run: vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
 
             -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,11 +122,3 @@ jobs:
             -
                 name: Run PHPStan
                 run: vendor/bin/phpstan analyse -c phpstan.neon -l max src/
-
-            -
-                name: Run PHPSpec
-                run: vendor/bin/phpspec run --ansi -f progress --no-interaction
-
-            -
-                name: Run PHPUnit
-                run: vendor/bin/phpunit --colors=always

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .idea
 
 .php_cs.cache
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "description": "Producer for synchronization products with sulu.",
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
 
-        "sylius/sylius": "^1.8",
-        "symfony/messenger": "^4.4|^5.0",
-        "symfony/config": "^4.4|^5.0",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0"
+        "sylius/sylius": "^1.12",
+        "symfony/messenger": "^5.0|^6.0",
+        "symfony/config": "^5.0|^6.0",
+        "symfony/dependency-injection": "^5.0|^6.0",
+        "symfony/http-kernel": "^5.0|^6.0",
+        "symfony/serializer": "^5.0|^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.15",
+        "friendsofphp/php-cs-fixer": "^2.15 || ^3.0",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
@@ -24,13 +24,11 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^8.2",
-        "symfony/browser-kit": "^4.4 || ^5.0",
-        "symfony/dotenv": "^4.4 || ^5.0",
+        "symfony/browser-kit": "^5.0 || ^6.0",
+        "symfony/dotenv": "^5.0 || ^6.0",
         "phpstan/extension-installer": "^1.0",
-        "sensiolabs/security-checker": "^6.0",
-        "symfony/intl": "^4.4 || ^5.0",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.0",
-        "symfony/web-server-bundle": "^4.4 || ^5.0"
+        "symfony/intl": "^5.0 || ^6.0",
+        "symfony/web-profiler-bundle": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,7 +38,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": false
+        }
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "description": "Producer for synchronization products with sulu.",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^7.4 || ^8.0",
 
-        "sylius/sylius": "^1.12",
-        "symfony/messenger": "^5.0|^6.0",
-        "symfony/config": "^5.0|^6.0",
-        "symfony/dependency-injection": "^5.0|^6.0",
-        "symfony/http-kernel": "^5.0|^6.0",
-        "symfony/serializer": "^5.0|^6.0"
+        "sylius/sylius": "1.11.* || 1.12.*",
+        "symfony/messenger": "^4.4 || ^5.4 || ^6.0",
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/serializer": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15 || ^3.0",
@@ -24,11 +24,11 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^8.2",
-        "symfony/browser-kit": "^5.0 || ^6.0",
-        "symfony/dotenv": "^5.0 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dotenv": "^4.4 || ^5.4 || ^6.0",
         "phpstan/extension-installer": "^1.0",
-        "symfony/intl": "^5.0 || ^6.0",
-        "symfony/web-profiler-bundle": "^5.0 || ^6.0"
+        "symfony/intl": "^4.4 || ^5.4 || ^6.0",
+        "symfony/web-profiler-bundle": "^4.4 || ^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,6 @@ parameters:
 
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
+        - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isAccountNonExpired\(\)\./'
+        - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isAccountNonLocked\(\)\./'
+        - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isCredentialsNonExpired\(\)\./'

--- a/src/Command/BaseSynchronizeCommand.php
+++ b/src/Command/BaseSynchronizeCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseSynchronizeCommand extends Command
 {
-    const BULK_SIZE = 50;
+    public const BULK_SIZE = 50;
 
     /**
      * @var EntityManagerInterface


### PR DESCRIPTION
Hi 👋 

As this bundle is already used by some projects, that are for sure upgrading to more modern Sylius and Symfony versions, I propose bumping the required Sylius version to 1.11+. Symfony can still stay on 4.4/5.4/6+, as these are versions supported by Sylius 1.11 and 1.12 combined :)

I've also simplified the build a little bit to make it work and reliable, but for sure it would be better to provide an actual test application to test the features of the plugin 🚀 🖖 