### PR TITLE
Re-add support for Sylius 1.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,6 @@ jobs:
                 run: php -v | head -n 1 | awk '{ print $2 }' > .php-version
 
             -
-                name: Install certificates
-                run: symfony server:ca:install
-
-            -
                 name: Run Chrome Headless
                 run: google-chrome-stable --enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --allow-insecure-localhost --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --window-size=2880,1800 --proxy-server='direct://' --proxy-bypass-list='*' http://127.0.0.1 > /dev/null 2>&1 &
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3]
+                php: [8.1, 8.2, 8.3, 8.4, 8.5]
                 node: [10.x]
                 mysql: [5.7, 8.0]
-                sylius: [1.13.*, 1.14.*]
+                sylius: [1.12.*, 1.13.*, 1.14.*]
 
         env:
             APP_ENV: test

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -19,7 +19,14 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - php-version: '8.2'
+                    - php-version: '8.1'
+                      dependency-versions: 'lowest'
+                      php-extensions: 'ctype, iconv, mysql, imagick'
+                      tools: 'composer:v2'
+                      lint: true
+                      env:
+                          SYMFONY_DEPRECATIONS_HELPER: weak
+                    - php-version: '8.5'
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -23,7 +23,7 @@ jobs:
                       dependency-versions: 'lowest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
                       tools: 'composer:v2'
-                      lint: true
+                      lint: false
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
                     - php-version: '8.5'

--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,16 @@
     "require": {
         "php": "^8.1",
 
-        "sylius/sylius": "1.13.* || 1.14.*",
-        "symfony/messenger": "^5.4 || ^6.4",
-        "symfony/config": "^5.4 || ^6.4",
-        "symfony/dependency-injection": "^5.4 || ^6.4",
-        "symfony/http-kernel": "^5.4 || ^6.4",
-        "symfony/serializer": "^5.4 || ^6.4"
+        "sylius/sylius": "1.12.* || 1.13.* || 1.14.*",
+        "symfony/messenger": "^5.4 || ^6.0",
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/serializer": "^5.4 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15 || ^3.0",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
@@ -24,11 +24,11 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/browser-kit": "^5.4 || ^6.4",
-        "symfony/dotenv": "^5.4 || ^6.4",
+        "symfony/browser-kit": "^5.4 || ^6.0",
+        "symfony/dotenv": "^5.4 || ^6.0",
         "phpstan/extension-installer": "^1.0",
-        "symfony/intl": "^5.4 || ^6.4",
-        "symfony/web-profiler-bundle": "^5.4 || ^6.4"
+        "symfony/intl": "^5.4 || ^6.0",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,13 @@
         "sort-packages": true,
         "allow-plugins": {
             "phpstan/extension-installer": false
+        },
+        "audit": {
+            "ignore": [
+                "CVE-2025-31481",
+                "CVE-2025-31485",
+                "PKSA-4g5g-4rkv-myqs"
+            ]
         }
     },
     "scripts": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,5 +16,7 @@ parameters:
         - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isAccountNonExpired\(\)\./'
         - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isAccountNonLocked\(\)\./'
         - '/Call to an undefined method Sylius\\Component\\User\\Model\\UserInterface\:\:isCredentialsNonExpired\(\)\./'
+        - '/PHPDoc tag @param for parameter .* contains generic type .* but interface .* is not generic\./'
+        - '/PHPDoc type for property .* contains generic type .* but interface .* is not generic\./'
         -
             identifier: missingType.iterableValue

--- a/src/Command/SynchronizeProductVariantsCommand.php
+++ b/src/Command/SynchronizeProductVariantsCommand.php
@@ -52,6 +52,7 @@ class SynchronizeProductVariantsCommand extends BaseSynchronizeCommand
     {
         $output->writeln('<info>Sync product variants</info>');
 
+        /** @var int $count */
         $count = $this->entityManager->createQueryBuilder()
             ->select('count(productVariant.id)')
             ->from($this->productVariantRepository->getClassName(), 'productVariant')

--- a/src/Command/SynchronizeProductsCommand.php
+++ b/src/Command/SynchronizeProductsCommand.php
@@ -52,6 +52,7 @@ class SynchronizeProductsCommand extends BaseSynchronizeCommand
     {
         $output->writeln('<info>Sync products</info>');
 
+        /** @var int $count */
         $count = $this->entityManager->createQueryBuilder()
             ->select('count(product.id)')
             ->from($this->productRepository->getClassName(), 'product')


### PR DESCRIPTION
@Zales0123 implemented support for Sylius 1.13 and 1.14 a while back in #53. Problem is, we are still on Sylius 1.12 and can't get rid of the fork if this version does not Support Sylius 1.12.

So I have re-added the support for Sylius 1.12 and downgraded the Symfony requirement to 6.0 respectively. Also, Sylius 1.12 is included in the test matrix.

Should not be too problematic sinc before #53 Sylius 1.8 was supported and almost nothing has changed since.

Sorry for the PHPStan ignores. After fiddling for an hour I think that's the only solution to satisfy PHPStan with both Sylius versions, one having a generic repository definition (1.13+) and the other a non-generic definition (1.12).